### PR TITLE
Add Nmap Window Option

### DIFF
--- a/SaltwaterTaffy.Demo/Program.cs
+++ b/SaltwaterTaffy.Demo/Program.cs
@@ -14,7 +14,7 @@ namespace SaltwaterTaffy.Demo
             Console.Write("Enter an IP or subnet: ");
             var target = new Target(Console.ReadLine().Trim());
             Console.WriteLine("Initializing scan of {0}", target);
-            ScanResult result = new Scanner(target).PortScan();
+            ScanResult result = new Scanner(target, System.Diagnostics.ProcessWindowStyle.Normal).PortScan();
             Console.WriteLine("Detected {0} host(s), {1} up and {2} down.", result.Total, result.Up, result.Down);
             foreach (Host i in result.Hosts)
             {

--- a/SaltwaterTaffy.Demo/Program.cs
+++ b/SaltwaterTaffy.Demo/Program.cs
@@ -14,7 +14,7 @@ namespace SaltwaterTaffy.Demo
             Console.Write("Enter an IP or subnet: ");
             var target = new Target(Console.ReadLine().Trim());
             Console.WriteLine("Initializing scan of {0}", target);
-            ScanResult result = new Scanner(target, System.Diagnostics.ProcessWindowStyle.Normal).PortScan();
+            ScanResult result = new Scanner(target, System.Diagnostics.ProcessWindowStyle.Hidden).PortScan();
             Console.WriteLine("Detected {0} host(s), {1} up and {2} down.", result.Total, result.Up, result.Down);
             foreach (Host i in result.Hosts)
             {

--- a/SaltwaterTaffy/Nmap.cs
+++ b/SaltwaterTaffy/Nmap.cs
@@ -516,12 +516,15 @@ namespace SaltwaterTaffy
     {
         /// <summary>
         ///     By default we try to find the path to the nmap executable by searching the path, the output XML file is a temporary file, and the nmap options are empty.
+        ///     
+        ///     Nmap ProcessWindowStyle is Hidden by default.
         /// </summary>
-        public NmapContext()
+        public NmapContext(ProcessWindowStyle windowStyle = ProcessWindowStyle.Hidden)
         {
             Path = GetPathToNmap();
             OutputPath = System.IO.Path.GetTempFileName();
             Options = new NmapOptions();
+            WindowStyle = windowStyle;
         }
 
         /// <summary>
@@ -543,6 +546,8 @@ namespace SaltwaterTaffy
         ///     The intended target
         /// </summary>
         public string Target { get; set; }
+
+        public ProcessWindowStyle WindowStyle { get; set; }
 
         /// <summary>
         ///     This searches our PATH environment variable for a particular file
@@ -607,7 +612,7 @@ namespace SaltwaterTaffy
             {
                 process.StartInfo.FileName = Path;
                 process.StartInfo.Arguments = string.Format("{0} {1}", Options, Target);
-                process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                process.StartInfo.WindowStyle = WindowStyle;
                 process.Start();
                 process.WaitForExit();
 

--- a/SaltwaterTaffy/Scanner.cs
+++ b/SaltwaterTaffy/Scanner.cs
@@ -11,6 +11,7 @@ using System.Net.Sockets;
 using SaltwaterTaffy.Container;
 using SaltwaterTaffy.Utility;
 using Simple.DotNMap;
+using System.Diagnostics;
 
 namespace SaltwaterTaffy
 {
@@ -183,12 +184,15 @@ namespace SaltwaterTaffy
             };
 
         /// <summary>
-        ///     Create a new scanner with an intended target
+        ///     Create a new scanner with an intended target and Nmap process window style.
+        ///     
+        ///     Nmap ProcessWindowStyle is hidden if no argument is passed in.
         /// </summary>
         /// <param name="target">Intended target</param>
-        public Scanner(Target target)
+        public Scanner(Target target, ProcessWindowStyle nmapWindowStyle = ProcessWindowStyle.Hidden)
         {
             Target = target;
+            NmapWindowStyle = nmapWindowStyle;
         }
 
         /// <summary>
@@ -200,6 +204,11 @@ namespace SaltwaterTaffy
         ///     NmapOptions that should persist between runs (e.g., --exclude foobar)
         /// </summary>
         public NmapOptions PersistentOptions { get; set; }
+
+        /// <summary>
+        ///     Set the Nmap process window style. Default is Hidden.
+        /// </summary>
+        public ProcessWindowStyle NmapWindowStyle { get; set; }
 
         /// <summary>
         ///     Create a new NmapContext with the intended target and our persistent options
@@ -214,7 +223,8 @@ namespace SaltwaterTaffy
 
             var ctx = new NmapContext
                 {
-                    Target = Target.ToString()
+                    Target = Target.ToString(),
+                    WindowStyle = NmapWindowStyle
                 };
 
             if (PersistentOptions != null)


### PR DESCRIPTION
Added an option to modify the Nmap process window style. This is useful if a project needs to display the process of an Nmap scan to its user. Our users get ancy if we present them with a spinning wheel.

The default Nmap window style is Hidden. All 45 tests pass with these code changes. I tried to stay consistent with your code style. 

Of course I just thought that I could get the output asynchronously and display it in our application. The work is done, and it's good enough for our usage.